### PR TITLE
fix: show full suggestion details by default

### DIFF
--- a/frontend/src/components/editor/editor-height-chain.css
+++ b/frontend/src/components/editor/editor-height-chain.css
@@ -35,12 +35,16 @@
 /* 隐藏调试卡片 */
 .debug-card { display: none !important; }
 
-/* 列表文本单行省略，防止撑宽 */
-.monaco-editor .suggest-widget .monaco-list-row .monaco-icon-label,
-.monaco-editor .suggest-widget .monaco-list-row .label-name,
-.monaco-editor .suggest-widget .monaco-list-row .monaco-highlighted-label {
-  max-width: 38ch; overflow: hidden; white-space: nowrap; text-overflow: ellipsis;
+/* 列表文本仅在右侧命中带触发单行省略，默认完整展示 */
+.monaco-editor .suggest-widget .monaco-list-row.show-readMore .monaco-icon-label,
+.monaco-editor .suggest-widget .monaco-list-row.show-readMore .label-name,
+.monaco-editor .suggest-widget .monaco-list-row.show-readMore .monaco-highlighted-label {
+  max-width: 38ch;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
+
 
 /* 1) 默认让右侧 details 整块“透鼠标”，不再抢行的 hover */
 .monaco-editor .suggest-widget .details,


### PR DESCRIPTION
## Summary
- display full completion detail text in suggestion panel by default
- only ellipsize text when row is in right-side hitband

## Testing
- `node - <<'NODE'\nconst fs = require('fs');\nconst puppeteer = require('puppeteer');\n(async () => {\n const css = fs.readFileSync('frontend/src/components/editor/editor-height-chain.css','utf-8');\n const html = `<!DOCTYPE html><html><head><style>${css}</style></head><body>\n<div class=\"monaco-editor\">\n<div class=\"suggest-widget\">\n<div class=\"monaco-list-row\"><div class=\"monaco-icon-label\"><span class=\"label-name\">label</span><span class=\"monaco-highlighted-label\">highlight</span></div></div>\n</div>\n</div>\n</body></html>`;\n const browser = await puppeteer.launch({headless:'new', args:['--no-sandbox']});\n const page = await browser.newPage();\n await page.setContent(html);\n const defaultOverflow = await page.$eval('.monaco-icon-label', el => getComputedStyle(el).textOverflow);\n await page.$eval('.monaco-list-row', el => el.classList.add('show-readMore'));\n const overflowAfter = await page.$eval('.monaco-icon-label', el => getComputedStyle(el).textOverflow);\n console.log('default', defaultOverflow);\n console.log('after', overflowAfter);\n await browser.close();\n})();\nNODE`
- `pnpm run check-no-new-ws`
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af04c524048329b26a7cc1f6ca3e9e