### PR TITLE
fix: correct CORS credentials configuration

### DIFF
--- a/python-backend/app.py
+++ b/python-backend/app.py
@@ -8,10 +8,18 @@ app = FastAPI(
 
 
 # CORS配置
+# Note: According to the CORS specification, credentialed requests cannot
+# use a wildcard ("*") for `Access-Control-Allow-Origin`. The previous
+# configuration set `allow_origins` to "*" while also enabling
+# `allow_credentials`, which results in browsers rejecting requests that
+# include credentials. Since the backend is currently configured with a
+# wildcard origin, disable credentials by default to avoid this runtime
+# error. If credentialed requests are required, specify explicit origins
+# instead of "*".
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],  # 可根据安全策略调整
-    allow_credentials=True,
+    allow_credentials=False,
     allow_methods=["*"],
     allow_headers=["*"],
 )


### PR DESCRIPTION
## Summary
- avoid invalid CORS setup by disabling credentials when origin is `*`
- document rationale for configuration

## Testing
- `python3 -m py_compile python-backend/app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ae94315eec8329bb81d2e043ebc9b3